### PR TITLE
fixed sandbox

### DIFF
--- a/src/clj_discord_bot/commands/sandbox.clj
+++ b/src/clj_discord_bot/commands/sandbox.clj
@@ -5,16 +5,24 @@
 
 (def sb (sandbox secure-tester))
 
+(defn result->string [object]
+  (with-out-str
+    (clojure.pprint/pprint object)))
+
 (defn run-code
   "```clj <your clojure code> ``` - Runs your Clojure Code"
   [type data]
-  (let [message (get data "content")
-        code (-> (clojure.string/replace message #"```clojure|```clj" "")
-                 (clojure.string/replace #"```" ""))
-        writer (java.io.StringWriter.)
-        result (sb (read-string code))]
-    (sb (read-string code) {#'*out* writer})
-    (discord/post-message (get data "channel_id")
-                          (if (nil? result)
-                            (str writer)
-                            result))))
+  (try
+    (let [message (get data "content")
+          code (-> (clojure.string/replace message #"```clojure|```clj" "")
+                   (clojure.string/replace #"```" ""))
+          writer (java.io.StringWriter.)
+          result (sb (read-string code))]
+      (sb (read-string code) {#'*out* writer})
+      (discord/post-message (get data "channel_id")
+                            (if (nil? result)
+                              (str "=> " (result->string writer))
+                              (str "=> " (result->string result)))))
+    (catch Exception e
+      (discord/post-message (get data "channel_id")
+                            (.getMessage e)))))

--- a/src/clj_discord_bot/commands/sandbox.clj
+++ b/src/clj_discord_bot/commands/sandbox.clj
@@ -6,8 +6,8 @@
 (def sb (sandbox secure-tester))
 
 (defn result->string [object]
-  (with-out-str
-    (clojure.pprint/pprint object)))
+  (str "=> "
+       (with-out-str (clojure.pprint/pprint object))))
 
 (defn run-code
   "```clj <your clojure code> ``` - Runs your Clojure Code"
@@ -18,11 +18,12 @@
                    (clojure.string/replace #"```" ""))
           writer (java.io.StringWriter.)
           result (sb (read-string code))]
-      (sb (read-string code) {#'*out* writer})
       (discord/post-message (get data "channel_id")
                             (if (nil? result)
-                              (str "=> " (result->string writer))
-                              (str "=> " (result->string result)))))
+                              (do
+                                (sb (read-string code) {#'*out* writer})
+                                (result->string writer))
+                              (result->string result))))
     (catch Exception e
       (discord/post-message (get data "channel_id")
                             (.getMessage e)))))

--- a/src/clj_discord_bot/core.clj
+++ b/src/clj_discord_bot/core.clj
@@ -39,9 +39,9 @@
   (let [message (get data "content")]
     (try
       (cond
-        (.contains message "clojure") (evangelize/get-propaganda type data)
         (.startsWith message "```clj") (sandbox/run-code type data)
         (.startsWith message "```clojure") (sandbox/run-code type data)
+        (.contains message "clojure") (evangelize/get-propaganda type data)
         (.startsWith message "!gamelist") (summon/game-list type data)
         (.startsWith message "!gameadd") (summon/game-add type data)
         (.equals "!help" message) (help type data)


### PR DESCRIPTION
sandbox takes priority over evangelizing
prints out results as a string repre.
prints out exceptions

note:
will result in some duplicate printing in some instances, but in others this adds value to the result.  For example (println "test") will print "test" as well as the representation of the string object.  Not sure how to get rid of this for now but better than failing.